### PR TITLE
Add Netlify status badge and deploy button the admin bar – also allow editors to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ From your WordPress dashboard
 1. **Visit** Plugins > Add New
 2. **Search** for "Deploy Webhook Button"
 3. **Install** plugin
-4. **Activate** the plugin 
+4. **Activate** the plugin
 5. **Click** on the new menu item "Deploy Netlify Webhook" and enter your site details/keys
 6. **Enter** enter your site_id, webhook POST address, Netlify API Key, and User-Agent
 7. **Read** the documentation to [get started](https://github.com/lukethacoder/wp-netlify-webhook-deploy)
@@ -55,6 +55,26 @@ From your WordPress dashboard
 4. Your field should look similar to this `SiteNameNoSpaces (site-name-url.com)`
 
 [![Netlify Site Info](https://github.com/lukethacoder/wp-netlify-webhook-deploy/blob/master/assets/screenshot-3.png)](https://github.com/lukethacoder/wp-netlify-webhook-deploy)
+
+---
+
+## Admin Bar
+
+A deploy button and the status badge of the last build is added to the admin bar. By default this will only be displayed to users that can `manage_options`.
+
+You may allow other user roles with these two filters:
+
+```
+add_filter('netlify_status_capability', function() {
+    return 'edit_pages';
+});
+
+add_filter('netlify_deploy_capability', function() {
+    return 'edit_pages';
+});
+```
+
+
 
 ---
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -116,7 +116,7 @@ class deployWebhook {
         <script type="text/javascript" >
         jQuery(document).ready(function($) {
             var _this = this;
-            $( "td > input" ).css( "width", "100%");
+            $( ".webhook-deploy_page_deploy_webhook_fields_sub td > input" ).css( "width", "100%");
 
             var webhook_url = '<?php echo(get_option('webhook_address')) ?>';
             var netlify_user_agent = '<?php echo(get_option('netlify_user_agent')) ?>';
@@ -278,7 +278,7 @@ class deployWebhook {
                 }
 
                 $button.addClass('running').css('opacity', '0.5');
-                
+
                 netlifyDeploy().done(function() {
                     var $badge = $('#admin-bar-netlify-deploy-status-badge');
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -278,7 +278,7 @@ class deployWebhook {
                 }
 
                 $button.addClass('running').css('opacity', '0.5');
-
+                
                 netlifyDeploy().done(function() {
                     var $badge = $('#admin-bar-netlify-deploy-status-badge');
 
@@ -440,13 +440,25 @@ class deployWebhook {
         $see_deploy_status = apply_filters( 'netlify_status_capability', 'manage_options' );
         $run_deploys = apply_filters( 'netlify_deploy_capability', 'manage_options' );
 
+        if ( current_user_can( $run_deploys ) ) {
+            $webhook_address = get_option( 'webhook_address' );
+
+            if ( $webhook_address ) {
+                $button = array(
+                    'id' => 'netlify-deploy-button',
+                    'title' => '<div style="cursor: pointer;"><span class="ab-icon dashicons dashicons-hammer"></span> <span class="ab-label">Deploy site</span></div>'
+                );
+
+                $admin_bar->add_node( $button );
+            }
+        }
+
         if ( current_user_can( $see_deploy_status ) ) {
             $netlify_site_id = get_option( 'netlify_site_id' );
 
             if ( $netlify_site_id ) {
                 $badge = array(
                     'id' => 'netlify-deploy-status-badge',
-                    'parent' => 'top-secondary',
                     'title' => sprintf( '<div style="display: flex; height: 100%%; align-items: center;">
                             <img id="admin-bar-netlify-deploy-status-badge" src="https://api.netlify.com/api/v1/badges/%s/deploy-status" alt="Netlify deply status" style="width: auto; height: 16px;" />
                         </div>', $netlify_site_id )
@@ -456,20 +468,6 @@ class deployWebhook {
             }
         }
 
-        if ( current_user_can( $run_deploys ) ) {
-            $webhook_address = get_option( 'webhook_address' );
-
-            if ( $webhook_address ) {
-                $button = array(
-                    'id' => 'netlify-deploy-button',
-                    'parent' => 'top-secondary',
-                    'title' => '<span class="ab-icon dashicons
-    dashicons-hammer"></span> <span class="ab-label">Deploy site</span>'
-                );
-
-                $admin_bar->add_node( $button );
-            }
-        }
     }
 
 }

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -354,10 +354,8 @@ class deployWebhook {
             $sub_capability = 'manage_options';
             $sub_slug = 'deploy_webhook_fields_sub';
             $sub_callback = array( $this, 'plugin_settings_subpage_content' );
-            $sub_icon = 'dashicons-admin-plugins';
-            $sub_position = 100;
 
-            add_submenu_page( $slug, $sub_page_title, $sub_menu_title, $sub_capability, $sub_slug, $sub_callback, $sub_icon, $sub_position );
+            add_submenu_page( $slug, $sub_page_title, $sub_menu_title, $sub_capability, $sub_slug, $sub_callback );
 
         }
 


### PR DESCRIPTION
This pull request adds the Netlify status badge and a deploy button to the WordPress admin bar.

<img width="245" alt="Bildschirmfoto 2019-08-29 um 12 24 43" src="https://user-images.githubusercontent.com/360736/63932764-1cc33a00-ca58-11e9-8c08-329c157f02bb.png">

To allow other user roles to be capable of deploying and seeing the status of the last build in the admin bar there are to filters:

```
/**
 * Allow editors to manage Netlify deploys
 */
add_filter('netlify_status_capability', function() {
    return 'edit_pages';
});

add_filter('netlify_deploy_capability', function() {
    return 'edit_pages';
});
```

By default only users that can `manage_options` are allowed.