### PR TITLE
Fix: The new permission hooks does not work for the "Webhook Deploy" menu and "Developer Settings" submenu

### DIFF
--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -340,7 +340,7 @@ class deployWebhook {
         if ( current_user_can( $run_deploys ) ) {
             $page_title = 'Deploy to Netlify';
             $menu_title = 'Webhook Deploy';
-            $capability = 'manage_options';
+            $capability = $run_deploys;
             $slug = 'deploy_webhook_fields';
             $callback = array( $this, 'plugin_settings_page_content' );
             $icon = 'dashicons-admin-plugins';
@@ -351,7 +351,7 @@ class deployWebhook {
         if ( current_user_can( $adjust_settings ) ) {
             $sub_page_title = 'Developer Settings';
             $sub_menu_title = 'Developer Settings';
-            $sub_capability = 'manage_options';
+            $sub_capability = $adjust_settings;
             $sub_slug = 'deploy_webhook_fields_sub';
             $sub_callback = array( $this, 'plugin_settings_subpage_content' );
 


### PR DESCRIPTION
The new permission hooks in v1.1 only work for the WP admin bar, not the regular menu items.

To test the hooks, you can use the example from the README.md file:
```php
add_filter('netlify_status_capability', function() {
    return 'edit_pages';
});

add_filter('netlify_deploy_capability', function() {
    return 'edit_pages';
});

add_filter('netlify_adjust_settings_capability', function() {
    return 'edit_pages';
});
```

However, if you add the above filters and then log in as an "author" or "editor" user, then you'll only see the "Deploy site" and "Netlify status" buttons in the WP admin bar.

You will not see the "Webhook Deploy" menu, and also not the "Developer Settings" submenu.

This pull request fixes this issue.