### PR TITLE
Added Scheduling Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,13 @@ From your WordPress dashboard
 
 ## Scheduling Netlify Builds
 
-Using cron jobs, is it possible to set daily, weekly, or monthly builds.
+Is it possible to set daily, weekly, or monthly builds. Using this plugin. Navigate to the 'Schedule Builds' settings page to select build time and date.
 
-WordPress cron jobs are not 100% reliable, so a little bit of work is required to fix this.
+### Consistant Scheduling
+
+WordPress cron jobs are not 100% reliable as they are only fired when the site is visited. A little bit of work may be required to fix this.
+
+#### If you have access to your hosting cPanel
 
 1. **Add** the following to your `wp-config.php` file - `define('DISABLE_WP_CRON', true);`
 2. Create a system cron
@@ -78,6 +82,14 @@ WordPress cron jobs are not 100% reliable, so a little bit of work is required t
 3. Click "Cron Jobs" (If this does not show up you may not have access to this functionality)
 4. Select "Once per hour" from the common settings
 5. Add this command to the command input `wget -q -O - https://your-domain.com/wp-cron.php?doing_wp_cron`
+
+#### If you do not have access to your cPanel
+
+A solution to not being able to set up cPanel cron jobs is to use a third party scheduler. This ensures that at a certain time every day your WordPress cron events will fire.
+
+1. Set up an account with https://cron-job.org
+2. Login and navigate to "Cronjobs"
+3. Create a new cron job for `https://your-domain.com/wp-cron.php?doing_wp_cron` firing a minimum of once an hour every hour.
 
 Now the Netlify hook (and all other cron jobs on your site) will run on time.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ From your WordPress dashboard
 
 ---
 
+## Scheduling Netlify Builds
+
+Using cron jobs, is it possible to set daily, weekly, or monthly builds.
+
+WordPress cron jobs are not 100% reliable, so a little bit of work is required to fix this.
+
+1. **Add** the following to your `wp-config.php` file - `define('DISABLE_WP_CRON', true);`
+2. Create a system cron
+
+### Creating a System Cron Job
+
+1. Log into your systems cpanel.
+2. Navigate to the Cron Jobs section - Search for "cron"
+3. Click "Cron Jobs" (If this does not show up you may not have access to this functionality)
+4. Select "Once per hour" from the common settings
+5. Add this command to the command input `wget -q -O - https://your-domain.com/wp-cron.php?doing_wp_cron`
+
+---
+
 ## Admin Bar
 
 A deploy button and the status badge of the last build is added to the admin bar. By default this will only be displayed to users that can `manage_options`.
@@ -96,8 +115,8 @@ Main Plugin page
 
 ## Links
 
-- [Website](https://github.com/lukethacoder/wp-netlify-webhook-deploy)
-- [Documentation](https://github.com/lukethacoder/wp-netlify-webhook-deploy)
+-   [Website](https://github.com/lukethacoder/wp-netlify-webhook-deploy)
+-   [Documentation](https://github.com/lukethacoder/wp-netlify-webhook-deploy)
 
 ---
 
@@ -105,18 +124,18 @@ Main Plugin page
 
 #### 1.1.0
 
-- Add Deploy Button and Deploy Status to admin bar
-- Add `manage_options` for devs to manage permissions
-- Nice comments in `php` code
-- Remove un-needed `add_submenu_items()` params
+-   Add Deploy Button and Deploy Status to admin bar
+-   Add `manage_options` for devs to manage permissions
+-   Nice comments in `php` code
+-   Remove un-needed `add_submenu_items()` params
 
 #### 1.0.0
 
-- Fixed UI
-- Seperate Developer Settings and User Build Screen
+-   Fixed UI
+-   Seperate Developer Settings and User Build Screen
 
 #### 0.1.0
 
-- Initial Release
+-   Initial Release
 
 View full changelog: [here](https://github.com/lukethacoder/deploy-webhook-button)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ WordPress cron jobs are not 100% reliable, so a little bit of work is required t
 4. Select "Once per hour" from the common settings
 5. Add this command to the command input `wget -q -O - https://your-domain.com/wp-cron.php?doing_wp_cron`
 
+Now the Netlify hook (and all other cron jobs on your site) will run on time.
+
 ---
 
 ## Admin Bar

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -7,7 +7,7 @@
 Plugin Name: Webhook Netlify Deploy
 Plugin URI: http://github.com/lukethacoder/wp-webhook-netlify-deploy
 Description: Adds a Build Website button that sends a webhook request to build a netlify hosted website when clicked
-Version: 1.1.1
+Version: 1.1.2
 Author: Luke Secomb
 Author URI: https://lukesecomb.digital
 License: GPLv3 or later
@@ -114,7 +114,7 @@ class deployWebhook {
     /**
     * Schedule Builds (subpage) markup
     *
-    * @since 1.1.1
+    * @since 1.1.2
     **/
     public function plugin_settings_schedule_content() {?>
     	<div class="wrap">
@@ -660,7 +660,7 @@ class deployWebhook {
     * Check if scheduled builds have been enabled, and pass to
     * the enable function. Or disable.
     *
-    * @since 1.1.1
+    * @since 1.1.2
     **/
     public function build_schedule_options_updated() {
       $enable_builds = get_option( 'enable_scheduled_builds' );
@@ -678,7 +678,7 @@ class deployWebhook {
     *
     * Activate cron job to trigger build
     *
-    * @since 1.1.1
+    * @since 1.1.2
     **/
     public function set_build_schedule_cron() {
       $enable_builds = get_option( 'enable_scheduled_builds' );
@@ -698,7 +698,7 @@ class deployWebhook {
     *
     * Remove cron jobs set by this plugin
     *
-    * @since 1.1.1
+    * @since 1.1.2
     **/
     public function deactivate_scheduled_cron(){
       // find out when the last event was scheduled
@@ -711,7 +711,7 @@ class deployWebhook {
     *
     * Trigger Netlify Build
     *
-    * @since 1.1.1
+    * @since 1.1.2
     **/
     public function fire_netlify_webhook(){
       $netlify_user_agent = get_option('netlify_user_agent');

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -685,7 +685,9 @@ class deployWebhook {
       if( $enable_builds ){
         if( !wp_next_scheduled('scheduled_netlify_build') ) {
           $schedule = get_option( 'select_schedule_builds' );
-          wp_schedule_event( time(), $schedule[0], 'scheduled_netlify_build' );
+          $set_time = get_option( 'select_time_build' );
+          $timestamp = strtotime( $set_time );
+          wp_schedule_event( $timestamp , $schedule[0], 'scheduled_netlify_build' );
         }
       } else {
         $this->deactivate_scheduled_cron();

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -422,11 +422,11 @@ class deployWebhook {
       // add a 'weekly' interval
       $schedules['weekly'] = array(
         'interval' => 604800,
-        'display' => __('Once Weekly')
+        'display' => __('Once Weekly', 'webhook-netlify-deploy')
       );
       $schedules['monthly'] = array(
         'interval' => 2635200,
-        'display' => __('Once a month')
+        'display' => __('Once a month', 'webhook-netlify-deploy')
       );
 
       return $schedules;
@@ -478,30 +478,30 @@ class deployWebhook {
         $fields = array(
           array(
             'uid' => 'enable_scheduled_builds',
-            'label' => 'Enable Scheduled Events',
+            'label' => _('Enable Scheduled Events', 'webhook-netlify-deploy'),
             'section' => 'schedule_section',
             'type' => 'checkbox',
             'options' => array(
-              'enable' => 'Enable'
+              'enable' => _('Enable', 'webhook-netlify-deploy'),
               ),
             'default' =>  array()
           ),
           array(
             'uid' => 'select_time_build',
-            'label' => 'Select Time to Build',
+            'label' => _('Select Time to Build', 'webhook-netlify-deploy'),
             'section' => 'schedule_section',
             'type' => 'time',
             'default' => '00:00'
           ),
           array(
             'uid' => 'select_schedule_builds',
-            'label' => 'Select Build Schedule',
+            'label' => _('Select Build Schedule', 'webhook-netlify-deploy'),
             'section' => 'schedule_section',
             'type' => 'select',
             'options' => array(
-              'daily' => 'Daily',
-              'weekly' => 'Weekly',
-              'monthly' => 'Monthly'
+              'daily' => _('Daily', 'webhook-netlify-deploy'),
+              'weekly' => _('Weekly', 'webhook-netlify-deploy'),
+              'monthly' => _('Monthly', 'webhook-netlify-deploy'),
             ),
             'default' => array('week')
           )
@@ -521,7 +521,7 @@ class deployWebhook {
         $fields = array(
           array(
             'uid' => 'webhook_address',
-            'label' => 'Webhook Build URL',
+            'label' => _('Webhook Build URL', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
                 'placeholder' => 'https://',
@@ -529,7 +529,7 @@ class deployWebhook {
             ),
             array(
             'uid' => 'netlify_site_id',
-            'label' => 'Netlify site_id',
+            'label' => _('Netlify site_id', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
                 'placeholder' => 'e.g. 5b8e927e-82e1-4786-4770-a9a8321yes43',
@@ -537,15 +537,15 @@ class deployWebhook {
             ),
             array(
             'uid' => 'netlify_api_key',
-            'label' => 'Netlify API Key',
+            'label' => _('Netlify API Key', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
-                'placeholder' => 'GET O-AUTH TOKEN',
+                'placeholder' => _('GET O-AUTH TOKEN', 'webhook-netlify-deploy'),
                 'default' => '',
           ),
             array(
             'uid' => 'netlify_user_agent',
-            'label' => 'User-Agent Site Value',
+            'label' => _('User-Agent Site Value', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
                 'placeholder' => 'Website Name (and-website-url.netlify.com)',

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -563,7 +563,7 @@ class deployWebhook {
                     $iterator = 0;
                     foreach( $arguments['options'] as $key => $label ){
                         $iterator++;
-                        $options_markup .= sprintf( '<label for="%1$s_%6$s"><input id="%1$s_%6$s" name="%1$s[]" type="%2$s" value="%3$s" %4$s /> %5$s</label><br/>', $arguments['uid'], $arguments['type'], $key, checked( $value[ array_search( $key, $value, true ) ], $key, false ), $label, $iterator );
+                        $options_markup .= sprintf( '<label for="%1$s_%6$s"><input id="%1$s_%6$s" name="%1$s[]" type="%2$s" value="%3$s" %4$s /> %5$s</label><br/>', $arguments['uid'], $arguments['type'], $key, checked( $value && $value[ array_search( $key, $value, true ) ], $key, false ), $label, $iterator );
                     }
                     printf( '<fieldset>%s</fieldset>', $options_markup );
                 }

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -666,13 +666,11 @@ class deployWebhook {
     **/
     public function set_build_schedule_cron() {
       $enable_builds = get_option( 'enable_scheduled_builds' );
-      if( count($enable_builds) > 0 ){
-
+      if( $enable_builds ){
         if( !wp_next_scheduled('scheduled_netlify_build') ) {
           $schedule = get_option( 'select_schedule_builds' );
           wp_schedule_event( time(), $schedule[0], 'scheduled_netlify_build' );
         }
-
       } else {
         $this->deactivate_scheduled_cron();
       }

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -186,7 +186,7 @@ class deployWebhook {
         console.log('run_the_mighty_javascript');
         jQuery(document).ready(function($) {
             var _this = this;
-            $( ".webhook-deploy_page_developer_webhook_fields_sub td > input" ).css( "width", "100%");
+            $( ".webhook-deploy_page_developer_webhook_fields td > input" ).css( "width", "100%");
 
             var webhook_url = '<?php echo(get_option('webhook_address')) ?>';
             var netlify_user_agent = '<?php echo(get_option('netlify_user_agent')) ?>';

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -155,8 +155,8 @@ class deployWebhook {
             } ?>
     		<form method="POST" action="options.php">
                 <?php
-                    settings_fields( 'deploy_webhook_fields' );
-                    do_settings_sections( 'deploy_webhook_fields' );
+                    settings_fields( 'developer_webhook_fields' );
+                    do_settings_sections( 'developer_webhook_fields' );
                     submit_button();
                 ?>
     		</form>
@@ -178,7 +178,7 @@ class deployWebhook {
     public function run_the_mighty_javascript() {
         // TODO: split up javascript to allow to be dynamically imported as needed
         // $screen = get_current_screen();
-        // if ( $screen && $screen->parent_base != 'deploy_webhook_fields' && $screen->parent_base != 'deploy_webhook_fields_sub' ) {
+        // if ( $screen && $screen->parent_base != 'developer_webhook_fields' && $screen->parent_base != 'deploy_webhook_fields_sub' ) {
         //     return;
         // }
         ?>
@@ -186,7 +186,7 @@ class deployWebhook {
         console.log('run_the_mighty_javascript');
         jQuery(document).ready(function($) {
             var _this = this;
-            $( ".webhook-deploy_page_deploy_webhook_fields_sub td > input" ).css( "width", "100%");
+            $( ".webhook-deploy_page_developer_webhook_fields_sub td > input" ).css( "width", "100%");
 
             var webhook_url = '<?php echo(get_option('webhook_address')) ?>';
             var netlify_user_agent = '<?php echo(get_option('netlify_user_agent')) ?>';
@@ -409,7 +409,7 @@ class deployWebhook {
             $sub_page_title = 'Developer Settings';
             $sub_menu_title = 'Developer Settings';
             $sub_capability = 'manage_options';
-            $sub_slug = 'deploy_webhook_fields';
+            $sub_slug = 'developer_webhook_fields';
             $sub_callback = array( $this, 'plugin_settings_developer_content' );
 
             add_submenu_page( $slug, $sub_page_title, $sub_menu_title, $sub_capability, $sub_slug, $sub_callback );
@@ -450,7 +450,7 @@ class deployWebhook {
     **/
     public function setup_sections() {
         add_settings_section( 'schedule_section', 'Scheduling Settings', array( $this, 'section_callback' ), 'schedule_webhook_fields' );
-        add_settings_section( 'developer_section', 'Webhook Settings', array( $this, 'section_callback' ), 'deploy_webhook_fields' );
+        add_settings_section( 'developer_section', 'Webhook Settings', array( $this, 'section_callback' ), 'developer_webhook_fields' );
     }
 
     /**
@@ -553,8 +553,8 @@ class deployWebhook {
           )
         );
       foreach( $fields as $field ){
-          add_settings_field( $field['uid'], $field['label'], array( $this, 'field_callback' ), 'deploy_webhook_fields', $field['section'], $field );
-            register_setting( 'deploy_webhook_fields', $field['uid'] );
+          add_settings_field( $field['uid'], $field['label'], array( $this, 'field_callback' ), 'developer_webhook_fields', $field['section'], $field );
+            register_setting( 'developer_webhook_fields', $field['uid'] );
       }
     }
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -482,7 +482,7 @@ class deployWebhook {
           ),
           array(
             'uid' => 'select_schedule_builds',
-            'label' => 'User-Agent Site Value',
+            'label' => 'Select Build Schedule',
             'section' => 'schedule_section',
             'type' => 'select',
             'options' => array(
@@ -648,7 +648,7 @@ class deployWebhook {
     **/
     public function build_schedule_options_updated() {
       $enable_builds = get_option( 'enable_scheduled_builds' );
-      if( count($enable_builds) > 0 ){
+      if( $enable_builds ){
         // Clean any previous setting
         $this->deactivate_scheduled_cron();
         // Reset schedule

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -398,7 +398,7 @@ class deployWebhook {
         if ( current_user_can( $adjust_settings ) ) {
             $sub_page_title = 'Schedule Builds';
             $sub_menu_title = 'Schedule Builds';
-            $sub_capability = 'manage_options';
+            $sub_capability = $adjust_settings;
             $sub_slug = 'schedule_webhook_fields';
             $sub_callback = array( $this, 'plugin_settings_schedule_content' );
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -7,7 +7,7 @@
 Plugin Name: Webhook Netlify Deploy
 Plugin URI: http://github.com/lukethacoder/wp-webhook-netlify-deploy
 Description: Adds a Build Website button that sends a webhook request to build a netlify hosted website when clicked
-Version: 1.1.0
+Version: 1.1.1
 Author: Luke Secomb
 Author URI: https://lukesecomb.digital
 License: GPLv3 or later
@@ -48,6 +48,9 @@ class deployWebhook {
       add_action( 'admin_init', array( $this, 'setup_developer_fields' ) );
       add_action( 'admin_footer', array( $this, 'run_the_mighty_javascript' ) );
       add_action( 'admin_bar_menu', array( $this, 'add_to_admin_bar' ), 90 );
+
+      // Setup Cron Scheduling
+      add_action( 'schedule_cron', array( $this, 'schedule_cron' ) );
     }
 
     /**
@@ -95,7 +98,7 @@ class deployWebhook {
     /**
     * Schedule Builds (subpage) markup
     *
-    * @since 1.1.0
+    * @since 1.1.1
     **/
     public function plugin_settings_schedule_content() {?>
     	<div class="wrap">
@@ -607,6 +610,15 @@ class deployWebhook {
                 $admin_bar->add_node( $badge );
             }
         }
+
+    }
+
+    /**
+    * Add Deploy Button and Deployment Status to admin bar
+    *
+    * @since 1.1.1
+    **/
+    public function schedule_cron() {
 
     }
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -547,7 +547,6 @@ class deployWebhook {
                     $attributes = '';
                     $options_markup = '';
                     foreach( $arguments['options'] as $key => $label ){
-                                          echo $label; echo $key;
                         $options_markup .= sprintf( '<option value="%s" %s>%s</option>', $key, selected( $value[ array_search( $key, $value, true ) ], $key, false ), $label );
                     }
                     if( $arguments['type'] === 'multiselect' ){

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -50,7 +50,7 @@ class deployWebhook {
       add_action( 'admin_bar_menu', array( $this, 'add_to_admin_bar' ), 90 );
 
       // Setup Cron Scheduling
-      add_action( 'schedule_cron', array( $this, 'schedule_cron' ) );
+      add_action( 'admin_init', array( $this, 'schedule_cron' ) );
     }
 
     /**
@@ -614,12 +614,13 @@ class deployWebhook {
     }
 
     /**
-    * Add Deploy Button and Deployment Status to admin bar
+    *
+    * Manage the cron jobs for triggering builds
     *
     * @since 1.1.1
     **/
     public function schedule_cron() {
-
+      $enable_builds = get_option( 'enable_scheduled_builds' );
     }
 
 }

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -429,11 +429,6 @@ class deployWebhook {
         'display' => __('Once a month')
       );
 
-      $schedules['min'] = array(
-        'interval' => 100,
-        'display' => __('Once Weekly')
-      );
-
       return $schedules;
     }
 
@@ -692,7 +687,7 @@ class deployWebhook {
       if( $enable_builds ){
         if( !wp_next_scheduled('scheduled_netlify_build') ) {
           $schedule = get_option( 'select_schedule_builds' );
-          wp_schedule_event( time(), 'min', 'scheduled_netlify_build' );
+          wp_schedule_event( time(), $schedule[0], 'scheduled_netlify_build' );
         }
       } else {
         $this->deactivate_scheduled_cron();

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -449,7 +449,7 @@ class deployWebhook {
             'section' => 'schedule_section',
             'type' => 'checkbox',
             'options' => array(
-              'true' => 'Enable'
+              'enable' => 'Enable'
               ),
             'default' =>  array()
           ),
@@ -562,7 +562,7 @@ class deployWebhook {
                     $iterator = 0;
                     foreach( $arguments['options'] as $key => $label ){
                         $iterator++;
-                        $options_markup .= sprintf( '<label for="%1$s_%6$s"><input id="%1$s_%6$s" name="%1$s[]" type="%2$s" value="%3$s" %4$s /> %5$s</label><br/>', $arguments['uid'], $arguments['type'], $key, checked( $value && $value[ array_search( $key, $value, true ) ], $key, false ), $label, $iterator );
+                        $options_markup .= sprintf( '<label for="%1$s_%6$s"><input id="%1$s_%6$s" name="%1$s[]" type="%2$s" value="%3$s" %4$s /> %5$s</label><br/>', $arguments['uid'], $arguments['type'], $key, checked( count($value) > 0 ? $value[ array_search( $key, $value, true ) ] : false, $key, false ), $label, $iterator );
                     }
                     printf( '<fieldset>%s</fieldset>', $options_markup );
                 }

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -155,8 +155,8 @@ class deployWebhook {
             } ?>
     		<form method="POST" action="options.php">
                 <?php
-                    settings_fields( 'developer_webhook_fields' );
-                    do_settings_sections( 'developer_webhook_fields' );
+                    settings_fields( 'deploy_webhook_fields' );
+                    do_settings_sections( 'deploy_webhook_fields' );
                     submit_button();
                 ?>
     		</form>
@@ -178,7 +178,7 @@ class deployWebhook {
     public function run_the_mighty_javascript() {
         // TODO: split up javascript to allow to be dynamically imported as needed
         // $screen = get_current_screen();
-        // if ( $screen && $screen->parent_base != 'developer_webhook_fields' && $screen->parent_base != 'deploy_webhook_fields_sub' ) {
+        // if ( $screen && $screen->parent_base != 'deploy_webhook_fields' && $screen->parent_base != 'deploy_webhook_fields_sub' ) {
         //     return;
         // }
         ?>
@@ -186,7 +186,7 @@ class deployWebhook {
         console.log('run_the_mighty_javascript');
         jQuery(document).ready(function($) {
             var _this = this;
-            $( ".webhook-deploy_page_developer_webhook_fields_sub td > input" ).css( "width", "100%");
+            $( ".webhook-deploy_page_deploy_webhook_fields_sub td > input" ).css( "width", "100%");
 
             var webhook_url = '<?php echo(get_option('webhook_address')) ?>';
             var netlify_user_agent = '<?php echo(get_option('netlify_user_agent')) ?>';
@@ -409,7 +409,7 @@ class deployWebhook {
             $sub_page_title = 'Developer Settings';
             $sub_menu_title = 'Developer Settings';
             $sub_capability = 'manage_options';
-            $sub_slug = 'developer_webhook_fields';
+            $sub_slug = 'deploy_webhook_fields';
             $sub_callback = array( $this, 'plugin_settings_developer_content' );
 
             add_submenu_page( $slug, $sub_page_title, $sub_menu_title, $sub_capability, $sub_slug, $sub_callback );
@@ -450,7 +450,7 @@ class deployWebhook {
     **/
     public function setup_sections() {
         add_settings_section( 'schedule_section', 'Scheduling Settings', array( $this, 'section_callback' ), 'schedule_webhook_fields' );
-        add_settings_section( 'developer_section', 'Webhook Settings', array( $this, 'section_callback' ), 'developer_webhook_fields' );
+        add_settings_section( 'developer_section', 'Webhook Settings', array( $this, 'section_callback' ), 'deploy_webhook_fields' );
     }
 
     /**
@@ -553,8 +553,8 @@ class deployWebhook {
           )
         );
       foreach( $fields as $field ){
-          add_settings_field( $field['uid'], $field['label'], array( $this, 'field_callback' ), 'developer_webhook_fields', $field['section'], $field );
-            register_setting( 'developer_webhook_fields', $field['uid'] );
+          add_settings_field( $field['uid'], $field['label'], array( $this, 'field_callback' ), 'deploy_webhook_fields', $field['section'], $field );
+            register_setting( 'deploy_webhook_fields', $field['uid'] );
       }
     }
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -685,10 +685,10 @@ class deployWebhook {
     * @since 1.1.1
     **/
     public function deactivate_scheduled_cron(){
-      // // find out when the last event was scheduled
-    	// $timestamp = wp_next_scheduled ('scheduled_netlify_build');
-    	// // unschedule previous event if any
-    	// wp_unschedule_event ($timestamp, 'scheduled_netlify_build');
+      // find out when the last event was scheduled
+    	$timestamp = wp_next_scheduled ('scheduled_netlify_build');
+    	// unschedule previous event if any
+    	wp_unschedule_event ($timestamp, 'scheduled_netlify_build');
     }
 
     /**

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -486,9 +486,9 @@ class deployWebhook {
             'section' => 'schedule_section',
             'type' => 'select',
             'options' => array(
-              'day' => 'Daily',
-              'week' => 'Weekly',
-              'month' => 'Monthly'
+              'daily' => 'Daily',
+              'weekly' => 'Weekly',
+              'monthly' => 'Monthly'
             ),
             'default' => array('week')
           )
@@ -665,7 +665,6 @@ class deployWebhook {
     * @since 1.1.1
     **/
     public function set_build_schedule_cron() {
-
       $enable_builds = get_option( 'enable_scheduled_builds' );
       if( count($enable_builds) > 0 ){
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -490,13 +490,8 @@ class deployWebhook {
             'uid' => 'select_time_build',
             'label' => 'Select Time to Build',
             'section' => 'schedule_section',
-            'type' => 'select',
-            'options' => array(
-              'daily' => 'Daily',
-              'weekly' => 'Weekly',
-              'monthly' => 'Monthly'
-            ),
-            'default' => array('week')
+            'type' => 'time',
+            'default' => '00:00'
           ),
           array(
             'uid' => 'select_schedule_builds',
@@ -583,6 +578,9 @@ class deployWebhook {
             case 'number':
                 printf( '<input name="%1$s" id="%1$s" type="%2$s" placeholder="%3$s" value="%4$s" />', $arguments['uid'], $arguments['type'], $arguments['placeholder'], $value );
                 break;
+            case 'time':
+              printf( '<input name="%1$s" id="%1$s" type="time" value="%2$s" />', $arguments['uid'], $value );
+              break;
             case 'textarea':
                 printf( '<textarea name="%1$s" id="%1$s" placeholder="%2$s" rows="5" cols="50">%3$s</textarea>', $arguments['uid'], $arguments['placeholder'], $value );
                 break;

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -414,7 +414,6 @@ class deployWebhook {
     }
 
     public function custom_cron_intervals($schedules) {
-      error_log('f');
       // add a 'weekly' interval
       $schedules['weekly'] = array(
         'interval' => 604800,

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -65,7 +65,7 @@ class deployWebhook {
       add_filter( 'cron_schedules', array( $this, 'custom_cron_intervals' ) );
 
       // Link event to function
-      add_action('scheduled_netlify_build', array( $this, 'trigger_netlify_by_cron' ) );
+      add_action('scheduled_netlify_build', array( $this, 'fire_netlify_webhook' ) );
 
     }
 
@@ -713,7 +713,7 @@ class deployWebhook {
     *
     * @since 1.1.1
     **/
-    public function trigger_netlify_by_cron(){
+    public function fire_netlify_webhook(){
       $netlify_user_agent = get_option('netlify_user_agent');
       $webhook_url = get_option('webhook_address');
       if($netlify_user_agent && $webhook_url){
@@ -723,8 +723,9 @@ class deployWebhook {
             "User-Agent" => $netlify_user_agent,
           )
         );
-      	$response = wp_remote_post($webhook_url, $options);
+        return wp_remote_post($webhook_url, $options);
       }
+      return false;
     }
 
 }

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -44,7 +44,7 @@ class deployWebhook {
 
       // Add Settings and Fields
     	add_action( 'admin_init', array( $this, 'setup_sections' ) );
-      add_action( 'admin_init', array( $this, 'setup_scheduler_fields' ) );
+      add_action( 'admin_init', array( $this, 'setup_schedule_fields' ) );
       add_action( 'admin_init', array( $this, 'setup_developer_fields' ) );
       add_action( 'admin_footer', array( $this, 'run_the_mighty_javascript' ) );
       add_action( 'admin_bar_menu', array( $this, 'add_to_admin_bar' ), 90 );
@@ -116,20 +116,6 @@ class deployWebhook {
                     submit_button();
                 ?>
         </form>
-
-        <div>
-          <input type="checkbox" id="enable_scheduled_builds" name="enable_scheduled_builds">
-          <label for="enable_scheduled_builds">Enable Scheduled Builds</label>
-        </div>
-        <div>
-          <label for="select_schedule_builds">Choose a scheduling option:</label>
-          <select id="select_schedule_builds">
-            <option value="daily">Daily</option>
-            <option value="weekly">Weekly</option>
-            <option value="monthly">Monthly</option>
-          </select>
-        </div>
-
     	</div> <?php
     }
 
@@ -448,24 +434,31 @@ class deployWebhook {
     }
 
     /**
-    * Fields used for scheduler input data
+    * Fields used for schedule input data
     *
     * @since 1.1.0
     **/
-    public function setup_scheduler_fields() {
+    public function setup_schedule_fields() {
         $fields = array(
           array(
-          'uid' => 'netlify_user_agent',
+          'uid' => 'enable_scheduled_builds',
+          'label' => 'Enable Scheduled Events',
+          'section' => 'schedule_section',
+          'type' => 'checkbox',
+              'options' => ['Enable'],
+              'default' => '',
+          ),
+          array(
+          'uid' => 'select_schedule_builds',
           'label' => 'User-Agent Site Value',
           'section' => 'schedule_section',
-          'type' => 'text',
-              'placeholder' => 'Website Name (and-website-url.netlify.com)',
-              'default' => '',
+          'type' => 'select',
+              'options' => ['Daily', 'Weekly', 'Monthly'],
           ),
         );
     	foreach( $fields as $field ){
-        	add_settings_field( $field['uid'], $field['label'], array( $this, 'field_callback' ), 'developer_webhook_fields', $field['section'], $field );
-            register_setting( 'scheduler_webhook_fields', $field['uid'] );
+        	add_settings_field( $field['uid'], $field['label'], array( $this, 'field_callback' ), 'schedule_webhook_fields', $field['section'], $field );
+            register_setting( 'schedule_webhook_fields', $field['uid'] );
     	}
     }
 

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -395,7 +395,7 @@ class deployWebhook {
             add_menu_page( $page_title, $menu_title, $capability, $slug, $callback, $icon, $position );
         }
 
-        if ( current_user_can( $run_deploys ) ) {
+        if ( current_user_can( $adjust_settings ) ) {
             $sub_page_title = 'Schedule Builds';
             $sub_menu_title = 'Schedule Builds';
             $sub_capability = 'manage_options';

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -478,30 +478,30 @@ class deployWebhook {
         $fields = array(
           array(
             'uid' => 'enable_scheduled_builds',
-            'label' => _('Enable Scheduled Events', 'webhook-netlify-deploy'),
+            'label' => __('Enable Scheduled Events', 'webhook-netlify-deploy'),
             'section' => 'schedule_section',
             'type' => 'checkbox',
             'options' => array(
-              'enable' => _('Enable', 'webhook-netlify-deploy'),
+              'enable' => __('Enable', 'webhook-netlify-deploy'),
               ),
             'default' =>  array()
           ),
           array(
             'uid' => 'select_time_build',
-            'label' => _('Select Time to Build', 'webhook-netlify-deploy'),
+            'label' => __('Select Time to Build', 'webhook-netlify-deploy'),
             'section' => 'schedule_section',
             'type' => 'time',
             'default' => '00:00'
           ),
           array(
             'uid' => 'select_schedule_builds',
-            'label' => _('Select Build Schedule', 'webhook-netlify-deploy'),
+            'label' => __('Select Build Schedule', 'webhook-netlify-deploy'),
             'section' => 'schedule_section',
             'type' => 'select',
             'options' => array(
-              'daily' => _('Daily', 'webhook-netlify-deploy'),
-              'weekly' => _('Weekly', 'webhook-netlify-deploy'),
-              'monthly' => _('Monthly', 'webhook-netlify-deploy'),
+              'daily' => __('Daily', 'webhook-netlify-deploy'),
+              'weekly' => __('Weekly', 'webhook-netlify-deploy'),
+              'monthly' => __('Monthly', 'webhook-netlify-deploy'),
             ),
             'default' => array('week')
           )
@@ -521,7 +521,7 @@ class deployWebhook {
         $fields = array(
           array(
             'uid' => 'webhook_address',
-            'label' => _('Webhook Build URL', 'webhook-netlify-deploy'),
+            'label' => __('Webhook Build URL', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
                 'placeholder' => 'https://',
@@ -529,7 +529,7 @@ class deployWebhook {
             ),
             array(
             'uid' => 'netlify_site_id',
-            'label' => _('Netlify site_id', 'webhook-netlify-deploy'),
+            'label' => __('Netlify site_id', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
                 'placeholder' => 'e.g. 5b8e927e-82e1-4786-4770-a9a8321yes43',
@@ -537,15 +537,15 @@ class deployWebhook {
             ),
             array(
             'uid' => 'netlify_api_key',
-            'label' => _('Netlify API Key', 'webhook-netlify-deploy'),
+            'label' => __('Netlify API Key', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
-                'placeholder' => _('GET O-AUTH TOKEN', 'webhook-netlify-deploy'),
+                'placeholder' => __('GET O-AUTH TOKEN', 'webhook-netlify-deploy'),
                 'default' => '',
           ),
             array(
             'uid' => 'netlify_user_agent',
-            'label' => _('User-Agent Site Value', 'webhook-netlify-deploy'),
+            'label' => __('User-Agent Site Value', 'webhook-netlify-deploy'),
             'section' => 'developer_section',
             'type' => 'text',
                 'placeholder' => 'Website Name (and-website-url.netlify.com)',

--- a/netlify-webhook-deploy.php
+++ b/netlify-webhook-deploy.php
@@ -436,25 +436,35 @@ class deployWebhook {
     /**
     * Fields used for schedule input data
     *
+    * Based off this article:
+    * @link https://www.smashingmagazine.com/2016/04/three-approaches-to-adding-configurable-fields-to-your-plugin/
+    *
     * @since 1.1.0
     **/
     public function setup_schedule_fields() {
         $fields = array(
           array(
-          'uid' => 'enable_scheduled_builds',
-          'label' => 'Enable Scheduled Events',
-          'section' => 'schedule_section',
-          'type' => 'checkbox',
-              'options' => ['Enable'],
-              'default' => '',
+            'uid' => 'enable_scheduled_builds',
+            'label' => 'Enable Scheduled Events',
+            'section' => 'schedule_section',
+            'type' => 'checkbox',
+            'options' => array(
+              'true' => 'Enable'
+              ),
+            'default' =>  array()
           ),
           array(
-          'uid' => 'select_schedule_builds',
-          'label' => 'User-Agent Site Value',
-          'section' => 'schedule_section',
-          'type' => 'select',
-              'options' => ['Daily', 'Weekly', 'Monthly'],
-          ),
+            'uid' => 'select_schedule_builds',
+            'label' => 'User-Agent Site Value',
+            'section' => 'schedule_section',
+            'type' => 'select',
+            'options' => array(
+              'day' => 'Daily',
+              'week' => 'Weekly',
+              'month' => 'Monthly'
+            ),
+            'default' => array('week')
+          )
         );
     	foreach( $fields as $field ){
         	add_settings_field( $field['uid'], $field['label'], array( $this, 'field_callback' ), 'schedule_webhook_fields', $field['section'], $field );
@@ -537,6 +547,7 @@ class deployWebhook {
                     $attributes = '';
                     $options_markup = '';
                     foreach( $arguments['options'] as $key => $label ){
+                                          echo $label; echo $key;
                         $options_markup .= sprintf( '<option value="%s" %s>%s</option>', $key, selected( $value[ array_search( $key, $value, true ) ], $key, false ), $label );
                     }
                     if( $arguments['type'] === 'multiselect' ){

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,10 @@ From your WordPress dashboard
 
 == Changelog ==
 
+= 1.1.2 =
+* Added Netlify scheduling settings
+* Refactored settings names to allow easier scaling
+
 = 1.1.1 =
 * Bug fix for new permission hooks not working for "Webhook Deploy" menu and "Developer Settings" submenu
 


### PR DESCRIPTION
Hi,

Following on from this issue: https://github.com/lukethacoder/wp-webhook-netlify-deploy/issues/13

I have added functionality to run daily/weekly/monthly builds. Any cron jobs that get set up by the plugin are automatically removed when the plugin is disabled.

There was a need to restructure the fields that build the settings pages, so there may be some breaking changes when a user installs the new version - may need to re-add data. This was going to happen at some point, now it is easy to scale.

Let me know your thoughts!

Cheers,
Rob